### PR TITLE
Fix for oc-5928; jiffy:encode can return iolists as well as binaries.

### DIFF
--- a/src/chef_index_queue.erl
+++ b/src/chef_index_queue.erl
@@ -105,7 +105,9 @@ publish(Data, RoutingKey) ->
   %%        amqp_channel:call(name, {...}) -> ok|blocked|closing
   %% blocked or closing count as errors to us, and letting errors bubble up
   %% seems fine.
-  ok = bunnyc:publish(?SERVER, RoutingKey, jiffy:encode(Data)).
+
+  %% Jiffy may return an iolist, but publish only takes binaries.
+  ok = bunnyc:publish(?SERVER, RoutingKey, erlang:iolist_to_binary(jiffy:encode(Data))).
 
 -spec routing_key(uuid_binary()) -> binary().
 routing_key(ObjectID) ->


### PR DESCRIPTION
bunnyc:publish (actually bunnyc:handle_call, line 169) matches Message against type binary(). However jiffy:encode can on occasion return an iolist. 

For example the following hunk of ejson generates an iolist with jiffy.

{[{<<"silly_size">>,100000000000000000000}]}

This patch detects this and converts to binary. No test case for this yet; I've not had a chance to do the proper mocking of bunnyc to make this work.
