### PR TITLE
Ma/ipv6 parse helper

### DIFF
--- a/src/chef_index_sup.erl
+++ b/src/chef_index_sup.erl
@@ -51,7 +51,8 @@ amqp_child_spec() ->
             error_logger:info_msg("RabbitMQ config disabled. Indexing for search is disabled.~n"),
             [];
         false ->
-            Host = envy:get(chef_index, rabbitmq_host, string),
+            %% This uses the key 'ip_mode' in chef_index to decide how to parse the address
+            Host = envy_parse:host_to_ip(chef_index, rabbitmq_host),
             Port = envy:get(chef_index,rabbitmq_port, non_neg_integer),
             User = envy:get(chef_index,rabbitmq_user, binary),
             Password = envy:get(chef_index,rabbitmq_password, binary),


### PR DESCRIPTION
Fixes to use envy's new api for address parsing. Let me know what you think of the API.

Can not be merged w/o envy changes being updated. See https://github.com/manderson26/envy/pull/7

This needs squashing, but I left it unsquashed to expose the history to review.

@marcparadise @seth @hosh @sdelano @oferrigni 
